### PR TITLE
Ignore whitespace in chat and popup rules to align their pattern matching

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -348,6 +348,11 @@ local messagehandlers = {
           end
         end
 
+        -- Remove whitesppace from to-be-found text (atm chat does not detect whitespace, popup does)
+        if find then
+          find = string.gsub(find, "%s+", "")
+        end
+
         if type == 'craftingprogress' or type == 'stat' then
           threshold = threshold / 100.0
         end
@@ -927,6 +932,8 @@ bolt.onrender2d(function (event)
         if p then
           local message = modules.popup:tryreadpopup(event, i + verticesperimage)
           if message then
+            -- Remove whitespace from popup message to align with chat detection
+            message = string.gsub(message, "%s+", "")
             popupfound = true
             if message ~= lastpopupmessage then
               lastpopupmessage = message


### PR DESCRIPTION
Since we don't have a way to find whitespace in chat (yet), it would be best that the chat-to-be-found ignored whitespaces (otherwise it might get confusing for users). I also propose doing the same to popup text, even though that can detect whitespace, to align both methods of pattern matching.l